### PR TITLE
chore: hold typescript at 6.x

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -32,6 +32,10 @@
   // docker:enableMajor preset, this is disabled by default
   packageRules: [
     { matchPackagePatterns: ["^lavaforge\\.org/"], enabled: false },
+    // TypeScript 7 is the native port and no longer ships the JS compiler API.
+    // ts-node (which pulumi's nodejs runtime registers) and typescript-eslint
+    // both need it, so stay on 6.x until they support the native compiler.
+    { matchPackageNames: ["typescript"], allowedVersions: "<7" },
     {
       matchPackageNames: ["ghcr.io/linuxserver/jellyfin"],
       allowedVersions: "<2021",


### PR DESCRIPTION
TypeScript 7 is the native port. The npm package exports only `version` and `versionMajorMinor` — no JS compiler API:

```
$ node -e "const ts=require('typescript'); console.log(ts.version, typeof ts.sys, Object.keys(ts))"
7.0.2 undefined [ 'version', 'versionMajorMinor' ]
```

Pulumi's nodejs runtime registers ts-node 10.9.2 before loading `index.ts`, which dies immediately on the missing API (this is the failure on #738):

```
error: TypeError: Cannot read properties of undefined (reading 'fileExists')
    at readConfig (.../ts-node/src/configuration.ts:161:25)
    at Object.register (.../ts-node/src/index.ts:591:15)
    at Object.run (.../@pulumi/cmd/run/run.ts:399:17)
```

`pnpm run lint` fails too — typescript-eslint explicitly refuses TS 7.0 (typescript-eslint#10940).

TypeScript 6 is unaffected (`ts.sys` still present) — verified locally that ts-node compiles the full program under 6.0.3 and `pnpm run lint` is clean. So this pins renovate to `<7`; #738 gets closed and #603 stays open.

Drop the constraint once ts-node is out of the picture (or pulumi stops registering it) and typescript-eslint ships native-compiler support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)